### PR TITLE
feat(config): configurar ModelMapper como bean de Spring (#13)

### DIFF
--- a/src/main/java/madstodolist/config/ModelMapperConfig.java
+++ b/src/main/java/madstodolist/config/ModelMapperConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ModelMapperConfig {
-
     @Bean
     public ModelMapper modelMapper() {
         return new ModelMapper();


### PR DESCRIPTION
- Resuelve #13 
- Crea paquete madstodolist.config  
- Añade clase ModelMapperConfig anotada con @Configuration  
- Declara método @Bean public ModelMapper modelMapper()  
- Agrega test unitario ModelMapperConfigTest para verificar bean  
- (Opcional) Test ModelMapperMappingTest para mapeo entidad→DTO