### PR TITLE
feat(auth): añadir GlobalControllerAdvice para exponer usuarioLogeado…

### DIFF
--- a/src/main/java/madstodolist/controller/GlobalControllerAdvice.java
+++ b/src/main/java/madstodolist/controller/GlobalControllerAdvice.java
@@ -1,0 +1,28 @@
+// src/main/java/madstodolist/controller/GlobalControllerAdvice.java
+package madstodolist.controller;
+
+import madstodolist.authentication.ManagerUserSession;
+import madstodolist.dto.UsuarioData;
+import madstodolist.service.UsuarioService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class GlobalControllerAdvice {
+
+    @Autowired
+    private ManagerUserSession managerUserSession;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @ModelAttribute("usuarioLogeado")
+    public UsuarioData usuarioLogeado() {
+        Long id = managerUserSession.usuarioLogeado();
+        if (id != null) {
+            return usuarioService.findById(id);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
- closes #38 
- Se añade la clase GlobalControllerAdvice:
- Anotada con @ControllerAdvice.
- Método @ModelAttribute("usuarioLogeado") que obtiene el ID de ManagerUserSession.
- Si hay sesión, recupera UsuarioData con UsuarioService.findById(id); si no, devuelve null.
- Permite acceder a ${usuarioLogeado} desde cualquier plantilla Thymeleaf sin pasar el modelo en cada controlador.