### PR TITLE
feat(navbar): incluir fragmento navbar en todas las plantillas

### DIFF
--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
   <head th:replace="fragments :: head (titulo='Acerca de')"></head>
   <body>
+    <div th:replace="fragments :: navbar"></div>
     <div class="container-fluid">
       <div class="container-fluid">
         <h1>ToDoList</h1>

--- a/src/main/resources/templates/formEditarTarea.html
+++ b/src/main/resources/templates/formEditarTarea.html
@@ -1,26 +1,39 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="fragments :: head (titulo='Login')"></head>
 
-<head th:replace="fragments :: head (titulo='Login')"></head>
+  <body>
+    <div th:replace="fragments :: navbar"></div>
+    <div class="container-fluid">
+      <h2 th:text="'Modificación de la tarea ' + ${tarea.getId()}"></h2>
 
-<body>
-<div class="container-fluid">
-
-    <h2 th:text="'Modificación de la tarea ' + ${tarea.getId()}"></h2>
-
-    <form method="post" th:action="@{/tareas/{id}/editar(id=${tarea.id})}" th:object="${tareaData}">
+      <form
+        method="post"
+        th:action="@{/tareas/{id}/editar(id=${tarea.id})}"
+        th:object="${tareaData}"
+      >
         <div class="col-6">
-        <div class="form-group">
+          <div class="form-group">
             <label for="titulo">Título de la tarea:</label>
-            <input class="form-control" id="titulo" name="titulo" required th:field="*{titulo}" type="text"/>
+            <input
+              class="form-control"
+              id="titulo"
+              name="titulo"
+              required
+              th:field="*{titulo}"
+              type="text"
+            />
+          </div>
+          <button class="btn btn-primary" type="submit">Modificar tarea</button>
+          <a
+            class="btn btn-link"
+            th:href="@{/usuarios/{id}/tareas(id=${tarea.usuarioId})}"
+            >Cancelar</a
+          >
         </div>
-        <button class="btn btn-primary" type="submit">Modificar tarea</button>
-        <a class="btn btn-link" th:href="@{/usuarios/{id}/tareas(id=${tarea.usuarioId})}">Cancelar</a>
-        </div>
-    </form>
-</div>
+      </form>
+    </div>
 
-<div th:replace="fragments::javascript"/>
-
-</body>
+    <div th:replace="fragments::javascript" />
+  </body>
 </html>

--- a/src/main/resources/templates/formNuevaTarea.html
+++ b/src/main/resources/templates/formNuevaTarea.html
@@ -1,26 +1,41 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+  <head th:replace="fragments :: head (titulo='Login')"></head>
 
-<head th:replace="fragments :: head (titulo='Login')"></head>
+  <body>
+    <div th:replace="fragments :: navbar"></div>
+    <div class="container-fluid">
+      <h2
+        th:text="'Nueva tarea para el usuario ' + ${usuario.getNombre()}"
+      ></h2>
 
-<body>
-<div class="container-fluid">
-
-    <h2 th:text="'Nueva tarea para el usuario ' + ${usuario.getNombre()}"></h2>
-
-    <form method="post" th:action="@{/usuarios/{id}/tareas/nueva(id=${usuario.id})}" th:object="${tareaData}">
+      <form
+        method="post"
+        th:action="@{/usuarios/{id}/tareas/nueva(id=${usuario.id})}"
+        th:object="${tareaData}"
+      >
         <div class="col-6">
-        <div class="form-group">
+          <div class="form-group">
             <label for="titulo">Título de la tarea:</label>
-            <input class="form-control" id="titulo" name="titulo" required th:field="*{titulo}" type="text"/>
+            <input
+              class="form-control"
+              id="titulo"
+              name="titulo"
+              required
+              th:field="*{titulo}"
+              type="text"
+            />
+          </div>
+          <button class="btn btn-primary" type="submit">Crear tarea</button>
+          <a
+            class="btn btn-link"
+            th:href="@{/usuarios/{id}/tareas(id=${usuario.id})}"
+            >Cancelar</a
+          >
         </div>
-        <button class="btn btn-primary" type="submit">Crear tarea</button>
-        <a class="btn btn-link" th:href="@{/usuarios/{id}/tareas(id=${usuario.id})}">Cancelar</a>
-        </div>
-    </form>
-</div>
+      </form>
+    </div>
 
-<div th:replace="fragments::javascript"/>
-
-</body>
+    <div th:replace="fragments::javascript" />
+  </body>
 </html>

--- a/src/main/resources/templates/listaTareas.html
+++ b/src/main/resources/templates/listaTareas.html
@@ -4,6 +4,7 @@
 <head th:replace="fragments :: head (titulo='Login')"></head>
 
 <body>
+<div th:replace="fragments :: navbar"></div>
 <div class="container-fluid">
 
     <div class="row mt-3">


### PR DESCRIPTION
- closes #40 
- Añadido `<div th:replace="fragments :: navbar"></div>` justo después de <body> en:
  • listaTareas.html  
  • formNuevaTarea.html  
  • formEditarTarea.html  
  • about.html  
- Login y registro siguen sin el fragmento.  