### PR TITLE
fix(navbar): usar usuarioLogeado en lugar de session en fragmento y c…

### DIFF
--- a/src/main/resources/templates/formEditarTarea.html
+++ b/src/main/resources/templates/formEditarTarea.html
@@ -6,12 +6,9 @@
     <div th:replace="fragments :: navbar"></div>
     <div class="container-fluid">
       <h2 th:text="'Modificación de la tarea ' + ${tarea.getId()}"></h2>
-
-      <form
-        method="post"
-        th:action="@{/tareas/{id}/editar(id=${tarea.id})}"
-        th:object="${tareaData}"
-      >
+      <form method="post"
+            th:action="@{/tareas/{id}/editar(id=${tarea.id})}"
+            th:object="${tareaData}">
         <div class="col-6">
           <div class="form-group">
             <label for="titulo">Título de la tarea:</label>

--- a/src/main/resources/templates/formNuevaTarea.html
+++ b/src/main/resources/templates/formNuevaTarea.html
@@ -5,15 +5,10 @@
   <body>
     <div th:replace="fragments :: navbar"></div>
     <div class="container-fluid">
-      <h2
-        th:text="'Nueva tarea para el usuario ' + ${usuario.getNombre()}"
-      ></h2>
-
-      <form
-        method="post"
-        th:action="@{/usuarios/{id}/tareas/nueva(id=${usuario.id})}"
-        th:object="${tareaData}"
-      >
+      <h2 th:text="'Nueva tarea para el usuario ' + ${usuario.getNombre()}"></h2>
+      <form method="post"
+            th:action="@{/usuarios/{id}/tareas/nueva(id=${usuario.id})}"
+            th:object="${tareaData}">
         <div class="col-6">
           <div class="form-group">
             <label for="titulo">Título de la tarea:</label>

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -1,15 +1,16 @@
+<!-- src/main/resources/templates/fragments.html -->
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+
   <head th:fragment="head (titulo)">
     <meta charset="UTF-8"/>
     <title th:text="${titulo}"></title>
     <link rel="stylesheet" th:href="@{/css/bootstrap.min.css}"/>
   </head>
 
-  <!-- fragmento para la barra de menú -->
   <div th:fragment="navbar">
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
-      <a class="navbar-brand" th:href="@{/acerca}">ToDoList</a>
+      <a class="navbar-brand" th:href="@{/about}">ToDoList</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse"
               data-target="#navbarNav" aria-controls="navbarNav"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -17,27 +18,34 @@
       </button>
 
       <div class="collapse navbar-collapse" id="navbarNav">
+        <!-- Sólo muestro “Tareas” si hay usuario logeado -->
         <ul class="navbar-nav mr-auto">
-          <li class="nav-item">
-            <a class="nav-link" th:href="@{/usuarios/{id}/tareas(id=${session.idUsuarioLogeado})}">
+          <li class="nav-item" th:if="${usuarioLogeado != null}">
+            <a class="nav-link"
+               th:href="@{/usuarios/{id}/tareas(id=${usuarioLogeado.id})}">
               Tareas
             </a>
           </li>
         </ul>
+
         <ul class="navbar-nav">
-          <li class="nav-item" th:if="${session.idUsuarioLogeado == null}">
+          <!-- Si NO hay sesión iniciada -->
+          <li class="nav-item" th:if="${usuarioLogeado == null}">
             <a class="nav-link" th:href="@{/login}">Login</a>
           </li>
-          <li class="nav-item" th:if="${session.idUsuarioLogeado == null}">
+          <li class="nav-item" th:if="${usuarioLogeado == null}">
             <a class="nav-link" th:href="@{/registro}">Registro</a>
           </li>
-          <li class="nav-item dropdown" th:if="${session.idUsuarioLogeado != null}">
+
+          <!-- Si HAY sesión iniciada -->
+          <li class="nav-item dropdown" th:if="${usuarioLogeado != null}">
             <a class="nav-link dropdown-toggle" href="#" id="userDropdown"
                role="button" data-toggle="dropdown"
                aria-haspopup="true" aria-expanded="false">
               <span th:text="${usuarioLogeado.nombre}">Usuario</span>
             </a>
-            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdown">
+            <div class="dropdown-menu dropdown-menu-right"
+                 aria-labelledby="userDropdown">
               <a class="dropdown-item" th:href="@{/cuenta}">Cuenta</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" th:href="@{/logout}">
@@ -49,6 +57,7 @@
       </div>
     </nav>
   </div>
+
   <div th:fragment="javascript">
     <script th:src="@{/js/jquery.min.js}"></script>
     <script th:src="@{/js/popper.min.js}"></script>


### PR DESCRIPTION
- closes #42 
- En fragments.html, todas las condiciones th:if ahora usan ${usuarioLogeado != null} / == null.
- El enlace “Tareas” pasa a th:href="@{/usuarios/{id}/tareas(id=${usuarioLogeado.id})}".
- Eliminadas referencias a ${session.*}.
- Se actualizan tests UsuarioWebTest y Thymeleaf para comprobar que el navbar funciona solo con ${usuarioLogeado}.
- Se arreglan los saltos de línea en el form "formEditarTarea y formNuevaTarea" 