### PR TITLE
fix(navbar): quitar nombre de usuario en botón de cerrar sesión

### DIFF
--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -49,7 +49,7 @@
               <a class="dropdown-item" th:href="@{/cuenta}">Cuenta</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" th:href="@{/logout}">
-                Cerrar sesión <span th:text="${usuarioLogeado.nombre}">Usuario</span>
+                Cerrar sesión
               </a>
             </div>
           </li>


### PR DESCRIPTION
- closes #44 
- En fragments.html, sección navbar, se ha eliminado el <span th:text="${usuarioLogeado.nombre}"> dentro del enlace “Cerrar sesión”.
- Ahora el botón muestra únicamente “Cerrar sesión” sin repetir el nombre de usuario.