### PR TITLE
feat(controller): se añade UsuarioNotFoundException

### DIFF
--- a/src/main/java/madstodolist/controller/exception/UsuarioNotFoundException.java
+++ b/src/main/java/madstodolist/controller/exception/UsuarioNotFoundException.java
@@ -1,0 +1,8 @@
+package madstodolist.controller.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Usuario no encontrado")
+public class UsuarioNotFoundException extends RuntimeException {
+}


### PR DESCRIPTION
- closes #60 
- Nueva clase UsuarioNotFoundException anotada con @ResponseStatus(NOT_FOUND, reason="Usuario no encontrado").
- Controladores actualizados para lanzar esta excepción cuando un usuario no existe.