### PR TITLE
test(UsuarioServiceTest): agregar pruebas unitarias para UsuarioServicebyid 

### DIFF
--- a/src/test/java/madstodolist/service/UsuarioServiceTest.java
+++ b/src/test/java/madstodolist/service/UsuarioServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.text.SimpleDateFormat;
 import java.util.List;
 
 @SpringBootTest
@@ -176,5 +177,32 @@ public class UsuarioServiceTest {
         assertThat(lista).hasSize(2)
                 .extracting(UsuarioData::getEmail)
                 .containsExactlyInAnyOrder("a@a.com", "b@b.com");
+    }
+
+    @Test
+    void testFindByIdReturnsUsuario() throws Exception {
+        // GIVEN
+        UsuarioData u = new UsuarioData();
+        u.setEmail("x@x.com");
+        u.setPassword("pwd");
+        u.setNombre("Xavier");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        u.setFechaNacimiento(sdf.parse("1990-05-10"));
+        UsuarioData saved = usuarioService.registrar(u);
+
+        // WHEN
+        UsuarioData found = usuarioService.findById(saved.getId());
+
+        // THEN
+        assertThat(found).isNotNull();
+        assertThat(found.getId()).isEqualTo(saved.getId());
+        assertThat(found.getEmail()).isEqualTo("x@x.com");
+        assertThat(found.getNombre()).isEqualTo("Xavier");
+        assertThat(found.getFechaNacimiento()).isEqualTo(sdf.parse("1990-05-10"));
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        assertThat(usuarioService.findById(999L)).isNull();
     }
 }


### PR DESCRIPTION
- closes #66 
- Crea `testFindByIdReturnsUsuario()` en `UsuarioServiceTest`, que:
  - Registra un usuario de ejemplo.
  - Invoca `findById(...)` y comprueba que devuelve el DTO con sus campos correctamente.
- Crea `testFindByIdNotFound()` en `UsuarioServiceTest`, que:
  - Llama a `findById(999L)` y valida que retorna `null`.
- Garantiza cobertura de pruebas sobre el comportamiento de `findById`.